### PR TITLE
Verify/ptr const slice type

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1805,4 +1805,17 @@ mod verify {
         let offset: isize = kani::any();
         unsafe { test_ptr.offset(offset) };
     }
+
+    #[kani::proof_for_contract(<*const i32>::offset)]
+    fn check_offset_slice_i32(){
+        let mut arr: [i32; 5] = kani::any();
+        let test_ptr: *const i32 = arr.as_ptr();
+        let offset: isize = kani::any();
+
+        unsafe{
+            let new_ptr = test_ptr.offset(offset);
+            let _ = * new_ptr;
+        }
+    }
+
 }

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1806,15 +1806,6 @@ mod verify {
     use crate::kani;
 
     #[allow(unused)]
-    // #[kani::proof_for_contract(<*const i32>::offset)]
-    // fn check_offset_i32() {
-    //     let mut test_val: i32 = kani::any();
-    //     let test_ptr: *const i32 = &test_val;
-    //     let offset: isize = kani::any();
-    //     unsafe { 
-    //         test_ptr.offset(offset) 
-    //     };
-    // }
 
     #[kani::proof_for_contract(<*const i32>::offset)]
     fn check_offset_slice_i32(){


### PR DESCRIPTION
### Description:

This pull request introduces additional verification checks and contracts for raw pointer arithmetic in Rust using Kani. It implements preconditions and postconditions for the `add` and `sub` methods, ensuring safety when working with pointer offsets. Specifically, this includes:

- Adding preconditions using `kani::mem::can_dereference` to validate that the pointer can be dereferenced before and after performing `add` and `sub` operations.
- Implementing placeholder preconditions for further refinement (e.g., the valid range for `count`).
- Adding verification functions (`check_add_slice_i32`, `check_sub_slice_i32`, and `check_offset_slice_i32`) to test these operations on slices of integers (`i32`).

### Solution:

The solution addresses pointer arithmetic safety in Rust by leveraging Kani to perform formal verification. The `add` and `sub` functions for raw pointers are made safer by including verification annotations (`#[requires]` and `#[ensures]`) that check the validity of pointer dereferences. The tests ensure that these pointer operations are correctly modeled, catching any potential errors or invalid pointer usages.

This PR aims to resolve pointer arithmetic challenges by verifying behavior through formal proofs, adhering to safe coding practices in Rust's unsafe code blocks.

---

Resolves #74

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
