### PR TITLE
Verify/ptr mut refactor harness

### DIFF
--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -2218,7 +2218,7 @@ impl<T: ?Sized> PartialOrd for *mut T {
 mod verify {
     use crate::kani;
 
-    macro_rules! generate_mut_add_and_sub_harness {
+    macro_rules! generate_mut_arithmetic_harness {
         ($type:ty, $proof_name:ident, add) => {
             #[kani::proof_for_contract(<*mut $type>::add)]
             pub fn $proof_name() {
@@ -2264,59 +2264,8 @@ mod verify {
                     ptr_with_offset.sub(count);
                 }
             }
-        }
-    }
-
-    // <*mut T>:: add() integer types verification
-    generate_mut_add_and_sub_harness!(i8, check_mut_add_i8, add);
-    generate_mut_add_and_sub_harness!(i16, check_mut_add_i16, add);
-    generate_mut_add_and_sub_harness!(i32, check_mut_add_i32, add);
-    generate_mut_add_and_sub_harness!(i64, check_mut_add_i64, add);
-    generate_mut_add_and_sub_harness!(i128, check_mut_add_i128, add);
-    generate_mut_add_and_sub_harness!(isize, check_mut_add_isize, add);
-    generate_mut_add_and_sub_harness!(u8, check_mut_add_u8, add);
-    generate_mut_add_and_sub_harness!(u16, check_mut_add_u16, add);
-    generate_mut_add_and_sub_harness!(u32, check_mut_add_u32, add);
-    generate_mut_add_and_sub_harness!(u64, check_mut_add_u64, add);
-    generate_mut_add_and_sub_harness!(u128, check_mut_add_u128, add);
-    generate_mut_add_and_sub_harness!(usize, check_mut_add_usize, add);   
-
-    // <*mut T>:: add() unit type verification
-    generate_mut_add_and_sub_harness!((), check_mut_add_unit, add);
-
-    // <*mut T>:: add() composite types verification
-    generate_mut_add_and_sub_harness!((i8, i8), check_mut_add_tuple_1, add);
-    generate_mut_add_and_sub_harness!((f64, bool), check_mut_add_tuple_2, add);
-    generate_mut_add_and_sub_harness!((i32, f64, bool), check_mut_add_tuple_3, add);
-    generate_mut_add_and_sub_harness!((i8, u16, i32, u64, isize), check_mut_add_tuple_4, add);
-
-    // <*mut T>:: sub() integer types verification
-    generate_mut_add_and_sub_harness!(i8, check_mut_sub_i8, sub);
-    generate_mut_add_and_sub_harness!(i16, check_mut_sub_i16, sub);
-    generate_mut_add_and_sub_harness!(i32, check_mut_sub_i32, sub);
-    generate_mut_add_and_sub_harness!(i64, check_mut_sub_i64, sub);
-    generate_mut_add_and_sub_harness!(i128, check_mut_sub_i128, sub);
-    generate_mut_add_and_sub_harness!(isize, check_mut_sub_isize, sub);
-    generate_mut_add_and_sub_harness!(u8, check_mut_sub_u8, sub);
-    generate_mut_add_and_sub_harness!(u16, check_mut_sub_u16, sub);
-    generate_mut_add_and_sub_harness!(u32, check_mut_sub_u32, sub);
-    generate_mut_add_and_sub_harness!(u64, check_mut_sub_u64, sub);
-    generate_mut_add_and_sub_harness!(u128, check_mut_sub_u128, sub);
-    generate_mut_add_and_sub_harness!(usize, check_mut_sub_usize, sub);
-
-    // <*mut T>:: sub() unit type verification
-    generate_mut_add_and_sub_harness!((), check_mut_sub_unit, sub);
-
-    // <*mut T>:: sub() composite types verification
-    generate_mut_add_and_sub_harness!((i8, i8), check_mut_sub_tuple_1, sub);
-    generate_mut_add_and_sub_harness!((f64, bool), check_mut_sub_tuple_2, sub);
-    generate_mut_add_and_sub_harness!((i32, f64, bool), check_mut_sub_tuple_3, sub);
-    generate_mut_add_and_sub_harness!((i8, u16, i32, u64, isize), check_mut_sub_tuple_4, sub);
-  
-  
-    // fn <*mut T>::offset verification begin
-    macro_rules! generate_mut_offset_harness {
-      ($type:ty, $proof_name:ident) => {
+        };
+        ($type:ty, $proof_name:ident, offset) => {
             #[kani::proof_for_contract(<*mut $type>::offset)]
             pub fn $proof_name() {
                 let mut test_val: $type = kani::any::<$type>();
@@ -2340,26 +2289,72 @@ mod verify {
         };
     }
 
-    // fn <*mut T>::offset integer types verification
-    generate_mut_offset_harness!(i8, check_mut_offset_i8);
-    generate_mut_offset_harness!(i16, check_mut_offset_i16);
-    generate_mut_offset_harness!(i32, check_mut_offset_i32);
-    generate_mut_offset_harness!(i64, check_mut_offset_i64);
-    generate_mut_offset_harness!(i128, check_mut_offset_i128);
-    generate_mut_offset_harness!(isize, check_mut_offset_isize);
-    generate_mut_offset_harness!(u8, check_mut_offset_u8);
-    generate_mut_offset_harness!(u16, check_mut_offset_u16);
-    generate_mut_offset_harness!(u32, check_mut_offset_u32);
-    generate_mut_offset_harness!(u64, check_mut_offset_u64);
-    generate_mut_offset_harness!(u128, check_mut_offset_u128);
-    generate_mut_offset_harness!(usize, check_mut_offset_usize);
+    // <*mut T>:: add() integer types verification
+    generate_mut_arithmetic_harness!(i8, check_mut_add_i8, add);
+    generate_mut_arithmetic_harness!(i16, check_mut_add_i16, add);
+    generate_mut_arithmetic_harness!(i32, check_mut_add_i32, add);
+    generate_mut_arithmetic_harness!(i64, check_mut_add_i64, add);
+    generate_mut_arithmetic_harness!(i128, check_mut_add_i128, add);
+    generate_mut_arithmetic_harness!(isize, check_mut_add_isize, add);
+    generate_mut_arithmetic_harness!(u8, check_mut_add_u8, add);
+    generate_mut_arithmetic_harness!(u16, check_mut_add_u16, add);
+    generate_mut_arithmetic_harness!(u32, check_mut_add_u32, add);
+    generate_mut_arithmetic_harness!(u64, check_mut_add_u64, add);
+    generate_mut_arithmetic_harness!(u128, check_mut_add_u128, add);
+    generate_mut_arithmetic_harness!(usize, check_mut_add_usize, add);   
 
-    // fn <*mut T>::offset unit type verification
-    generate_mut_offset_harness!((), check_mut_offset_unit);
+    // <*mut T>:: add() unit type verification
+    generate_mut_arithmetic_harness!((), check_mut_add_unit, add);
 
-    // fn <*mut T>::offset composite type verification
-    generate_mut_offset_harness!((i8, i8), check_mut_offset_tuple_1);
-    generate_mut_offset_harness!((f64, bool), check_mut_offset_tuple_2);
-    generate_mut_offset_harness!((i32, f64, bool), check_mut_offset_tuple_3);
-    generate_mut_offset_harness!((i8, u16, i32, u64, isize), check_mut_offset_tuple_4);
+    // <*mut T>:: add() composite types verification
+    generate_mut_arithmetic_harness!((i8, i8), check_mut_add_tuple_1, add);
+    generate_mut_arithmetic_harness!((f64, bool), check_mut_add_tuple_2, add);
+    generate_mut_arithmetic_harness!((i32, f64, bool), check_mut_add_tuple_3, add);
+    generate_mut_arithmetic_harness!((i8, u16, i32, u64, isize), check_mut_add_tuple_4, add);
+
+    // <*mut T>:: sub() integer types verification
+    generate_mut_arithmetic_harness!(i8, check_mut_sub_i8, sub);
+    generate_mut_arithmetic_harness!(i16, check_mut_sub_i16, sub);
+    generate_mut_arithmetic_harness!(i32, check_mut_sub_i32, sub);
+    generate_mut_arithmetic_harness!(i64, check_mut_sub_i64, sub);
+    generate_mut_arithmetic_harness!(i128, check_mut_sub_i128, sub);
+    generate_mut_arithmetic_harness!(isize, check_mut_sub_isize, sub);
+    generate_mut_arithmetic_harness!(u8, check_mut_sub_u8, sub);
+    generate_mut_arithmetic_harness!(u16, check_mut_sub_u16, sub);
+    generate_mut_arithmetic_harness!(u32, check_mut_sub_u32, sub);
+    generate_mut_arithmetic_harness!(u64, check_mut_sub_u64, sub);
+    generate_mut_arithmetic_harness!(u128, check_mut_sub_u128, sub);
+    generate_mut_arithmetic_harness!(usize, check_mut_sub_usize, sub);
+
+    // <*mut T>:: sub() unit type verification
+    generate_mut_arithmetic_harness!((), check_mut_sub_unit, sub);
+
+    // <*mut T>:: sub() composite types verification
+    generate_mut_arithmetic_harness!((i8, i8), check_mut_sub_tuple_1, sub);
+    generate_mut_arithmetic_harness!((f64, bool), check_mut_sub_tuple_2, sub);
+    generate_mut_arithmetic_harness!((i32, f64, bool), check_mut_sub_tuple_3, sub);
+    generate_mut_arithmetic_harness!((i8, u16, i32, u64, isize), check_mut_sub_tuple_4, sub); 
+
+    // fn <*mut T>::offset() integer types verification
+    generate_mut_arithmetic_harness!(i8, check_mut_offset_i8, offset);
+    generate_mut_arithmetic_harness!(i16, check_mut_offset_i16, offset);
+    generate_mut_arithmetic_harness!(i32, check_mut_offset_i32, offset);
+    generate_mut_arithmetic_harness!(i64, check_mut_offset_i64, offset);
+    generate_mut_arithmetic_harness!(i128, check_mut_offset_i128, offset);
+    generate_mut_arithmetic_harness!(isize, check_mut_offset_isize, offset);
+    generate_mut_arithmetic_harness!(u8, check_mut_offset_u8, offset);
+    generate_mut_arithmetic_harness!(u16, check_mut_offset_u16, offset);
+    generate_mut_arithmetic_harness!(u32, check_mut_offset_u32, offset);
+    generate_mut_arithmetic_harness!(u64, check_mut_offset_u64, offset);
+    generate_mut_arithmetic_harness!(u128, check_mut_offset_u128, offset);
+    generate_mut_arithmetic_harness!(usize, check_mut_offset_usize, offset);
+
+    // fn <*mut T>::offset() unit type verification
+    generate_mut_arithmetic_harness!((), check_mut_offset_unit, offset);
+
+    // fn <*mut T>::offset() composite type verification
+    generate_mut_arithmetic_harness!((i8, i8), check_mut_offset_tuple_1, offset);
+    generate_mut_arithmetic_harness!((f64, bool), check_mut_offset_tuple_2, offset);
+    generate_mut_arithmetic_harness!((i32, f64, bool), check_mut_offset_tuple_3, offset);
+    generate_mut_arithmetic_harness!((i8, u16, i32, u64, isize), check_mut_offset_tuple_4, offset);
 }

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -409,9 +409,9 @@ impl<T: ?Sized> *mut T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[requires(
         count.checked_mul(core::mem::size_of::<T>() as isize).is_some() &&
-        kani::mem::same_allocation(self, self.wrapping_offset(count))
+        ((core::mem::size_of::<T>() == 0) || (kani::mem::same_allocation(self, self.wrapping_offset(count))))
     )]
-    #[ensures(|result| kani::mem::same_allocation(self as *const T, *result as *const T))]
+    #[ensures(|result| (core::mem::size_of::<T>() == 0) || kani::mem::same_allocation(self as *const T, *result as *const T))]
     pub const unsafe fn offset(self, count: isize) -> *mut T
     where
         T: Sized,
@@ -959,9 +959,9 @@ impl<T: ?Sized> *mut T {
     #[requires(
             count.checked_mul(core::mem::size_of::<T>()).is_some() &&
             count * core::mem::size_of::<T>() <= isize::MAX as usize &&
-            kani::mem::same_allocation(self, self.wrapping_add(count))
+            ((core::mem::size_of::<T>() == 0) || (kani::mem::same_allocation(self, self.wrapping_add(count))))
     )]
-    #[ensures(|result| kani::mem::same_allocation(self as *const T, *result as *const T))]
+    #[ensures(|result| (core::mem::size_of::<T>() == 0) || kani::mem::same_allocation(self as *const T, *result as *const T))]
     pub const unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,
@@ -1040,9 +1040,9 @@ impl<T: ?Sized> *mut T {
     #[requires(
         count.checked_mul(core::mem::size_of::<T>()).is_some() &&
         count * core::mem::size_of::<T>() <= isize::MAX as usize &&
-        kani::mem::same_allocation(self, self.wrapping_sub(count))
+        ((core::mem::size_of::<T>() == 0) || (kani::mem::same_allocation(self, self.wrapping_sub(count))))
     )]
-    #[ensures(|result| kani::mem::same_allocation(self as *const T, *result as *const T))]
+    #[ensures(|result| (core::mem::size_of::<T>() == 0) || kani::mem::same_allocation(self as *const T, *result as *const T))]
     pub const unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,
@@ -2293,7 +2293,7 @@ mod verify {
     generate_mut_arithmetic_harness!(usize, check_mut_add_usize, add);   
 
     // <*mut T>:: add() unit type verification
-    // generate_mut_arithmetic_harness!((), check_mut_add_unit, add);
+    generate_mut_arithmetic_harness!((), check_mut_add_unit, add);
 
     // <*mut T>:: add() composite types verification
     generate_mut_arithmetic_harness!((i8, i8), check_mut_add_tuple_1, add);
@@ -2316,7 +2316,7 @@ mod verify {
     generate_mut_arithmetic_harness!(usize, check_mut_sub_usize, sub);
 
     // <*mut T>:: sub() unit type verification
-    // generate_mut_arithmetic_harness!((), check_mut_sub_unit, sub);
+    generate_mut_arithmetic_harness!((), check_mut_sub_unit, sub);
 
     // <*mut T>:: sub() composite types verification
     generate_mut_arithmetic_harness!((i8, i8), check_mut_sub_tuple_1, sub);
@@ -2339,7 +2339,7 @@ mod verify {
     generate_mut_arithmetic_harness!(usize, check_mut_offset_usize, offset);
 
     // fn <*mut T>::offset() unit type verification
-    // generate_mut_arithmetic_harness!((), check_mut_offset_unit, offset);
+    generate_mut_arithmetic_harness!((), check_mut_offset_unit, offset);
 
     // fn <*mut T>::offset() composite type verification
     generate_mut_arithmetic_harness!((i8, i8), check_mut_offset_tuple_1, offset);

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -409,6 +409,7 @@ impl<T: ?Sized> *mut T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[requires(
         count.checked_mul(core::mem::size_of::<T>() as isize).is_some() &&
+        (self as isize).checked_add((count * core::mem::size_of::<T>() as isize)).is_some() &&
         ((core::mem::size_of::<T>() == 0) || (kani::mem::same_allocation(self, self.wrapping_offset(count))))
     )]
     #[ensures(|result| (core::mem::size_of::<T>() == 0) || kani::mem::same_allocation(self as *const T, *result as *const T))]
@@ -959,6 +960,7 @@ impl<T: ?Sized> *mut T {
     #[requires(
             count.checked_mul(core::mem::size_of::<T>()).is_some() &&
             count * core::mem::size_of::<T>() <= isize::MAX as usize &&
+            (self as isize).checked_add((count * core::mem::size_of::<T>()) as isize).is_some() &&
             ((core::mem::size_of::<T>() == 0) || (kani::mem::same_allocation(self, self.wrapping_add(count))))
     )]
     #[ensures(|result| (core::mem::size_of::<T>() == 0) || kani::mem::same_allocation(self as *const T, *result as *const T))]
@@ -1040,6 +1042,7 @@ impl<T: ?Sized> *mut T {
     #[requires(
         count.checked_mul(core::mem::size_of::<T>()).is_some() &&
         count * core::mem::size_of::<T>() <= isize::MAX as usize &&
+        (self as isize).checked_sub((count * core::mem::size_of::<T>()) as isize).is_some() &&
         ((core::mem::size_of::<T>() == 0) || (kani::mem::same_allocation(self, self.wrapping_sub(count))))
     )]
     #[ensures(|result| (core::mem::size_of::<T>() == 0) || kani::mem::same_allocation(self as *const T, *result as *const T))]
@@ -2232,8 +2235,8 @@ mod verify {
                 let offset: usize = kani::any();
                 let count: usize = kani::any();                
                 kani::assume(offset <= 1);
-                kani::assume(count <= 1);
-                kani::assume(offset + count <= 1);
+                // kani::assume(count <= 1);
+                // kani::assume(offset + count <= 1);
                 
                 let test_ptr: *mut $type = &mut test_val;
                 let ptr_with_offset: *mut $type = test_ptr.wrapping_add(offset);                   
@@ -2249,8 +2252,8 @@ mod verify {
                 let offset: usize = kani::any();
                 let count: usize = kani::any();
                 kani::assume(offset <= 1);
-                kani::assume(count <= 1); 
-                kani::assume(count <= offset);
+                // kani::assume(count <= 1); 
+                // kani::assume(count <= offset);
                 
                 let test_ptr: *mut $type = &mut test_val;
                 let ptr_with_offset: *mut $type = test_ptr.wrapping_add(offset);
@@ -2266,8 +2269,8 @@ mod verify {
                 let offset: usize = kani::any();
                 let count: isize = kani::any();
                 kani::assume(offset <= 1);
-                kani::assume(count >= -1 && count <= 1);
-                kani::assume(offset as isize + count >= 0 && offset as isize + count <= 1);    
+                // kani::assume(count >= -1 && count <= 1);
+                // kani::assume(offset as isize + count >= 0 && offset as isize + count <= 1);    
 
                 let test_ptr: *mut $type = &mut test_val;
                 let ptr_with_offset: *mut $type = test_ptr.wrapping_add(offset);                


### PR DESCRIPTION
**Modifications**
* Rewrite function contracts using the same_allocation api.
* Merged macros for add(), sub() and offset().

**Known Issue**
Currently all verification for unit types will fail because same_allocation does not support object with zero size.